### PR TITLE
vsphere module - Updated README.md with working example settings

### DIFF
--- a/metricbeat/module/vsphere/_meta/README.md
+++ b/metricbeat/module/vsphere/_meta/README.md
@@ -27,7 +27,10 @@ Now setup your metricbeat config to connect to Govcsim:
 
 ```
 - module: vsphere
-  metricsets: ["datastore, host, virtualmachine"]
+  metricsets:
+    - datastore
+    - host
+    - virtualmachine
   enabled: true
   period: 5s
   hosts: ["https://127.0.0.1:8989/sdk"]


### PR DESCRIPTION
Without the included changes, you get the following error on startup:

```
2017-06-21T11:35:36-04:00 CRIT Exiting: 1 error: metricset 'vsphere/datastore, vsphere/host, vsphere/virtualmachine' is not registered, metricset not found
```

